### PR TITLE
ebb: repaired some persName tagging errors in engDecameronTEI.xml

### DIFF
--- a/engDecameronTEI.xml
+++ b/engDecameronTEI.xml
@@ -1410,7 +1410,7 @@
 	God; but which of them is justified in so believing, is a question
 	which, like that of the rings, remains pendent.</q> 
       <milestone unit="locus" corresp="p01030017"/>The excellent
-      adroitness with which the Jew had contrived to <persName>eva</persName>de the snare
+      adroitness with which the Jew had contrived to evade the snare
       which he had laid for his feet was not lost upon Saladin. He therefore
       determined to let the Jew know his need, and did so, telling him
       at the same time what he had intended to do, in the event of his
@@ -1419,7 +1419,7 @@
       also gave him most munificent gifts with his lifelong amity and a
       great and honourable position near his person.</p></div><pb n="41"/><!--****************************************Novella 4*****************************************--><div type="novella" corresp="nov0104"><head>Novel IV</head><argument><p><milestone unit="locus" corresp="p01040001"/>A monk lapses into a sin meriting the most severe punishment,
  justly censures the same fault in his abbot, and
- thus <persName>eva</persName>des the penalty.</p></argument><floatingText type="frame"><body><p><milestone unit="locus" corresp="p01040002"/><!--(sc)-->The<!--(/sc)--> silence which followed the conclusion of <persName>Filomena</persName>'s tale
+ thus evades the penalty.</p></argument><floatingText type="frame"><body><p><milestone unit="locus" corresp="p01040002"/><!--(sc)-->The<!--(/sc)--> silence which followed the conclusion of <persName>Filomena</persName>'s tale
  was broken by <persName>Dioneo</persName>, who sate next her, and without waiting for
  the queen's word, for he knew that by the rule laid down at the
  commencement it was now his turn to speak, began on this wise:</p></body></floatingText><floatingText type="frame"><body><p><milestone unit="locus" corresp="p01040003"/>Loving ladies, if I have well understood the intention of you all, we
@@ -2443,7 +2443,7 @@
  souls of the father and mother of St. Julian, after which I pray God
  and St. Julian to provide me with a good inn for the night. <milestone unit="locus" corresp="p02020008"/>And
  many a time in the course of my life have I met with great perils by
- the way, and <persName>eva</persName>ding them all have found comfortable quarters for
+ the way, and evading them all have found comfortable quarters for
  the night: whereby my faith is assured, that St. Julian, in whose
  honour I say my paternoster, has gotten me this favour of God; nor
  should I look for a prosperous journey and a safe arrival at night, if
@@ -3646,7 +3646,7 @@
  could to persuade her to go with them. <milestone unit="locus" corresp="p02060024"/>So the gentle lady stayed
  with Madam Beritola, and after condoling with her at large on her
  misfortunes had food and clothing brought to her, and with the
- greatest difficulty in the world pr<persName>eva</persName>iled upon her to eat and dress
+ greatest difficulty in the world prevailed upon her to eat and dress
  herself. At last, after much beseeching, she induced her to depart
  from her oft-declared intention never to go where she might meet
  any that knew her, and accompany them to <placeName>Lunigiana</placeName>, taking with
@@ -3740,7 +3740,7 @@
  <pb n="110"/>confinement and duress, whereby the culprits should be brought to
  repent them of their fault in tears. <milestone unit="locus" corresp="p02060040"/>Thus, and with much more
  to the like effect, the devout lady urged her suit, and at length
- pr<persName>eva</persName>iled upon her husband to abandon his murderous design.
+ prevailed upon her husband to abandon his murderous design.
  Wherefore, he commanded that the pair should be confined in
  separate prisons, and closely guarded, and kept short of food and
  in sore discomfort, until further order; which was accordingly done;
@@ -4022,7 +4022,7 @@
  acquainted with the coil of misadventures in which her beauty
  involved a fair Saracen, who in the course of, perhaps, four years was
  wedded nine several times.</p></body></floatingText><p><milestone unit="locus" corresp="p02070008"/>There was of yore a Soldan of <placeName>Babylon</placeName>,<note><!--(i)-->I. e.<!--(/i)--> according to
- medi<persName>eva</persName>l usage, <placeName>Egypt</placeName>.</note> by name of Beminedab,
+ medieval usage, <placeName>Egypt</placeName>.</note> by name of Beminedab,
  who in his day had cause enough to be well content with his luck.
  <milestone unit="locus" corresp="p02070009"/>Many children male and female had he, and among them a daughter,
  <persName>Alatiel</persName> by name, who by common consent of all that saw her was
@@ -4212,7 +4212,7 @@
  hands on him, and threw him into the sea, and were already more
  than a mile on their course before any perceived that <persName>Marato</persName> was
  overboard. Which when the lady learned, and knew that he was
- irretri<persName>eva</persName>bly lost, she relapsed into her former plaintive mood. 
+ irretrievably lost, she relapsed into her former plaintive mood. 
 <milestone unit="locus" corresp="p02070041"/>But
  the twain were forthwith by her side with soft speeches and profuse
  promises, which, however ill she understood them, were not altogether
@@ -4511,7 +4511,7 @@
       in a little cabin in the poop. <milestone unit="locus" corresp="p02070089"/>Whereby that happened which on
       neither side was intended when they left <placeName>Rhodes</placeName>, to wit, that the
       darkness and the comfort and the warmth of the bed, forces of no
-      mean efficacy, did so pr<persName>eva</persName>il with them that dead <persName>Antioco</persName> was forgotten
+      mean efficacy, did so prevail with them that dead <persName>Antioco</persName> was forgotten
       alike as lover and as friend, and by a common impulse they
       began to wanton together, insomuch that before they were arrived
       at <placeName>Baffa</placeName>, where the Cypriote resided, they were indeed man and wife.
@@ -4722,7 +4722,7 @@
 	so richly has Fortune diversified it with episodes both strange and
 	sombre; wherefore selecting one such from this infinite store, I
 	say:</p></body></floatingText><p><milestone unit="locus" corresp="p02080004"/>That, after the transference of the Roman Empire from the
- Franks to the Germans, the greatest enmity pr<persName>eva</persName>iled between the
+ Franks to the Germans, the greatest enmity prevailed between the
  two nations, with warfare perpetual and relentless: wherefore,
  deeming that the offensive would be their best defence, the King of
  <placeName>France</placeName> and his son mustered all the forces they could raise from
@@ -7510,7 +7510,7 @@
  still much ruffled in spirit, was resolved not to let her go, until he
  had made his peace with her. So he addressed himself to soothe
  her; and by dint of most dulcet phrases and entreaties and adjurations
- he did at last pr<persName>eva</persName>il with her to give him her pardon; nay, by
+ he did at last prevail with her to give him her pardon; nay, by
  joint consent, they tarried there a great while to the exceeding great
  delight of both. <milestone unit="locus" corresp="p03060050"/>Indeed the lady, finding her lover's kisses smack
  much better than those of her husband, converted her asperity into
@@ -7779,7 +7779,7 @@
  text of the Gospel: Christ began to do and to teach?<note>As pointed out by
  Mr. Payne, these words are not from any of the
  Gospels, but from the first verse of the Acts of the Apostles. Boccaccio
- doubtless used <q><persName>Eva</persName>ngelio</q> in a large sense for the whole of the New
+ doubtless used <q><persName>Evangelio</persName></q> in a large sense for the whole of the New
  Testament.</note> 
 <milestone unit="locus" corresp="p03070043"/>Let
  <pb n="224"/>them practise first, and school us with their precepts afterwards. A
@@ -8129,7 +8129,7 @@
  else either by day or by night. <milestone unit="locus" corresp="p03080006"/>But learning that, however simple
  and inept in all other matters, <persName>Ferondo</persName> shewed excellent good sense
  in cherishing and watching over this wife of his, he almost despaired.
- However, being very astute, he pr<persName>eva</persName>iled so far with <persName>Ferondo</persName>, that he
+ However, being very astute, he prevailed so far with <persName>Ferondo</persName>, that he
  would sometimes bring his wife with him to take a little recreation
  in the abbey-garden, where he discoursed to them with all lowliness
  of the blessedness of life eternal, and the most pious works of many
@@ -8241,7 +8241,7 @@
  things of the abbot's sanctity, and so went home with them.</p><p><milestone unit="locus" corresp="p03080030"/>Some few days after, <persName>Ferondo</persName> being come to the abbey, the abbot
  no sooner saw him than he resolved to send him to purgatory. <milestone unit="locus" corresp="p03080031"/>So he
  selected from among his drugs a powder of marvellous virtue, which
- he had gotten in the L<persName>eva</persName>nt from a great prince, who averred that
+ he had gotten in the Levant from a great prince, who averred that
  'twas wont to be used by the Old Man of the Mountain, when he
  would send any one to or bring him from his paradise, and that,
  without doing the recipient any harm, 'twould induce in him, according
@@ -8870,7 +8870,7 @@ i.e.<!--(/i)--> Angel Gabriel.</note> before his resuscitation.</p><p><milestone
  giovane sopra uno de' loro letticelli, le 'nsegn&#242; come star si dovesse a
  dovere
  incarcerare quel maledetto da Dio. <milestone unit="locus" corresp="p03100022"/>La giovane, che mai pi&#249; non
- av<persName>eva</persName> in inferno messo diavolo alcuno, per la prima volta sent&#236; un
+ aveva in inferno messo diavolo alcuno, per la prima volta sent&#236; un
  poco di noja, per che ella disse a Rustico: <q>Per certo, padre mio,
  mala cosa dee essere questo Diavolo, e veramente nimico di Dio, ch&#232;
  ancora al ninferno, non che altrui, duole quando egli v' &#232; dentro
@@ -8886,7 +8886,7 @@ i.e.<!--(/i)--> Angel Gabriel.</note> before his resuscitation.</p><p><milestone
  ubbidiente
  sempre a trargliele si disponesse, avvenne che il giuoco le cominci&#242;
  a piacere, e cominci&#242; a dire a Rustico: <q>Ben veggio che il ver
- dic<persName>eva</persName>no que' valentuomini in <placeName>Capsa</placeName>, che il servire a Dio era cos&#236;
+ dicevano que' valentuomini in <placeName>Capsa</placeName>, che il servire a Dio era cos&#236;
  dolce cosa: e per certo io non mi ricordo che mai alcuna altra ne
  facessi, che di tanto diletto e piacer mi fosse, quanto &#232; il
  rimettere il
@@ -8895,7 +8895,7 @@ i.e.<!--(/i)--> Angel Gabriel.</note> before his resuscitation.</p><p><milestone
 <milestone unit="locus" corresp="p03100026"/>Per la qual
  cosa essa spesse volte andava a Rustico, e gli dicea: <q>Padre mio,
  io son qui venuta per servire a Dio e non per istare oziosa; andiamo
- a rimettere il Diavolo in inferno.</q> <milestone unit="locus" corresp="p03100027"/>La qual cosa faccendo, dic<persName>eva</persName>
+ a rimettere il Diavolo in inferno.</q> <milestone unit="locus" corresp="p03100027"/>La qual cosa faccendo, diceva
  ella alcuna volta: <q>Rustico, io non so perch&#232; il Diavolo si fugga
  di
  ninferno; ch&#232; s' egli vi stesse cos&#236; volentieri come il
@@ -8909,12 +8909,12 @@ i.e.<!--(/i)--> Angel Gabriel.</note> before his resuscitation.</p><p><milestone
  alla
  giovane che il Diavolo non era da gastigare n&#232; da rimettere in
  inferno,
- se non quando egli per superbia l<persName>eva</persName>sse il capo; e <q>noi per grazia di
+ se non quando egli per superbia levasse il capo; e <q>noi per grazia di
  Dio l'abbiamo s&#236; sgannato, che egli priega Iddio di starsi in
  pace</q>: e
  cos&#236; alquanto impose di silenzio alla giovane. 
 <milestone unit="locus" corresp="p03100029"/>La qual, poi che vide
- Rustico non la richied<persName>eva</persName> a dovere il Diavolo rimettere in inferno,
+ Rustico non la richiedeva a dovere il Diavolo rimettere in inferno,
  gli disse un giorno: <q>Rustico, se il Diavolo tuo &#232; gastigato e
  pi&#249; non ti d&#224; noja, me il mio ninferno non lascia stare: per
  che
@@ -8922,13 +8922,13 @@ i.e.<!--(/i)--> Angel Gabriel.</note> before his resuscitation.</p><p><milestone
  mio ninferno, com' io col mio ninferno ho ajutato a trarre la
  superbia al tuo Diavolo.</q> 
 <milestone unit="locus" corresp="p03100030"/>Rustico, che di radici d' erba e d' acqua
- vivea, pot<persName>eva</persName> male rispondere alle poste; e dissele che troppi diavoli
+ vivea, poteva male rispondere alle poste; e dissele che troppi diavoli
  vorrebbono essere a potere il ninferno attutare, ma che egli ne
  farebbe ci&#242; che per lui si potesse; c cos&#236; alcuna volta le
- sodisfac<persName>eva</persName>,
+ sodisfaceva,
  ma s&#236; era di rado che altro non era che gittare una fava in bocca al
  leone: di che la giovane, non parendole tanto servire a Dio quanto
- vol<persName>eva</persName>, mormorava anzi che no. 
+ voleva, mormorava anzi che no. 
 <milestone unit="locus" corresp="p03100031"/>However, the case standing thus
  (deficiency of power against superfluity of desire) between Rustico's
  Devil and <persName>Alibech</persName>'s hell, it chanced that a fire broke out in <placeName>Capsa</placeName>,
@@ -9669,7 +9669,7 @@ i.e.<!--(/i)--> Angel Gabriel.</note> before his resuscitation.</p><p><milestone
 <milestone unit="locus" corresp="p04010061"/>The Prince replied not for excess of grief;
  and the lady, feeling that her end was come, strained the dead heart
  to her bosom, saying: <q>Fare ye well; I take my leave of you;</q>
- and with eyelids drooped and every sense <persName>eva</persName>nished departed this
+ and with eyelids drooped and every sense evanished departed this
  life of woe. 
 <milestone unit="locus" corresp="p04010062"/>Such was the lamentable end of the loves of <persName>Guiscardo</persName>
  and Ghismonda; whom Tancred, tardily repentant of his harshness,
@@ -10101,7 +10101,7 @@ i.e.<!--(/i)--> Angel Gabriel.</note> before his resuscitation.</p><p><milestone
  you are willing to make of your wealth a common stock with me as
  third partner therein, and to choose some part of the world where
  we may live in careless ease upon our substance, without any manner
- of doubt I trust so to pr<persName>eva</persName>il that the three sisters with great part of
+ of doubt I trust so to prevail that the three sisters with great part of
  their father's substance shall come to live with us, wherever we shall
  see fit to go; whereby, each with his own lady, we shall live as
  three brethren, the happiest men in the world. 'Tis now for you to
@@ -10369,7 +10369,7 @@ i.e.<!--(/i)--> Angel Gabriel.</note> before his resuscitation.</p><p><milestone
  whose love it is that prompts me to take arms: all else I freely cede
  to you from this very hour. Forward, then; attack we this ship;
  success should be ours, for God favours our enterprise, nor lends her
- wind to <persName>eva</persName>de us.</q> 
+ wind to evade us.</q> 
 <milestone unit="locus" corresp="p04040018"/>Fewer words might have sufficed the illustrious
  <persName>Gerbino</persName>; for the rapacious Messinese that were with him were
  already bent heart and soul upon that to which by his harangue he
@@ -10431,7 +10431,7 @@ i.e.<!--(/i)--> Angel Gabriel.</note> before his resuscitation.</p><p><milestone
  to suffer the loss of his only grandson than to gain the reputation of
  a faithless king. <milestone unit="locus" corresp="p04040027"/>And so, miserably, within the compass of a few
  brief days, died the two lovers by woeful deaths, as I have told you,
- and without having known any joyance of their love.</p></div><pb n="296"/><!--********************************Novella 5*******************************--><div type="novella" corresp="nov0405"><head>Novel V</head><argument><p><milestone unit="locus" corresp="p04050001"/><!--(i)-->L<persName>isabetta</persName>'s brothers slay her lover: he appears to her in
+ and without having known any joyance of their love.</p></div><pb n="296"/><!--********************************Novella 5*******************************--><div type="novella" corresp="nov0405"><head>Novel V</head><argument><p><milestone unit="locus" corresp="p04050001"/><!--(i)--><persName>Lisabetta</persName>'s brothers slay her lover: he appears to her in
  a dream, and shews her where he is buried: she
  privily disinters the head, and sets it in a pot of
  basil, whereon she daily weeps a great while. The
@@ -10446,24 +10446,24 @@ i.e.<!--(/i)--> Angel Gabriel.</note> before his resuscitation.</p><p><milestone
 	the recent mention of <placeName>Messina</placeName>, where the matter befell.</p></body></floatingText><p><milestone unit="locus" corresp="p04050004"/>Know then that there were at <placeName>Messina</placeName> three young men, that
  were brothers and merchants, who were left very rich on the death
  of their father, who was of <placeName>San Gimignano</placeName>; and they had a sister,
- L<persName>isabetta</persName> by name, a girl fair enough, and no less debonair, but
+ <persName>Lisabetta</persName> by name, a girl fair enough, and no less debonair, but
  whom, for some reason or another, they had not as yet bestowed in
  marriage. <milestone unit="locus" corresp="p04050005"/>The three brothers had also in their shop a young Pisan,
  <persName>Lorenzo</persName> by name, who managed all their affairs, and who was so
- goodly of person and gallant, that L<persName>isabetta</persName> bestowed many a glance
+ goodly of person and gallant, that <persName>Lisabetta</persName> bestowed many a glance
  upon him, and began to regard him with extraordinary favour;
  which <persName>Lorenzo</persName> marking from time to time, gave up all his other
  amours, and in like manner began to affect her, and so, their loves
  being equal, 'twas not long before they took heart of grace, and did
  that which each most desired. <milestone unit="locus" corresp="p04050006"/>Wherein continuing to their no
  small mutual solace and delight, they neglected to order it with due
- <pb n="297"/>secrecy, whereby one night as L<persName>isabetta</persName> was going to <persName>Lorenzo</persName>'s
+ <pb n="297"/>secrecy, whereby one night as <persName>Lisabetta</persName> was going to <persName>Lorenzo</persName>'s
  room, she, all unwitting, was observed by the eldest of the brothers,
  who, albeit much distressed by what he had learnt, yet, being a
  young man of discretion, was swayed by considerations more seemly,
  and, allowing no word to escape him, spent the night in turning the
  affair over in his mind in divers ways. <milestone unit="locus" corresp="p04050007"/>On the morrow he told his
- brothers that which, touching L<persName>isabetta</persName> and <persName>Lorenzo</persName>, he had observed
+ brothers that which, touching <persName>Lisabetta</persName> and <persName>Lorenzo</persName>, he had observed
  in the night, which, that no shame might thence ensue either to
  them or to their sister, they after long consultation determined to pass
  over in silence, making as if they had seen or heard nought thereof,
@@ -10478,7 +10478,7 @@ i.e.<!--(/i)--> Angel Gabriel.</note> before his resuscitation.</p><p><milestone
  was ware of it. <milestone unit="locus" corresp="p04050009"/>On their return to <placeName>Messina</placeName> they gave out that they
  had sent him away on business; which was readily believed, because
  'twas what they had been frequently used to do. <milestone unit="locus" corresp="p04050010"/>But as <persName>Lorenzo</persName>
- did not return, and L<persName>isabetta</persName> questioned the brothers about him with
+ did not return, and <persName>Lisabetta</persName> questioned the brothers about him with
  great frequency and urgency, being sorely grieved by his long
  absence, it so befell that one day, when she was very pressing in her
  enquiries, one of the brothers said: <q>What means this? What
@@ -10493,7 +10493,7 @@ i.e.<!--(/i)--> Angel Gabriel.</note> before his resuscitation.</p><p><milestone
  <persName>Lorenzo</persName> came not back, she had at last fallen asleep, <persName>Lorenzo</persName>
  appeared to her in a dream, wan and in utter disarray, his clothes
  torn to shreds and sodden; and thus, as she thought, he spoke:
- <milestone unit="locus" corresp="p04050013"/><q>L<persName>isabetta</persName>, thou dost nought but call me, and vex thyself for my
+ <milestone unit="locus" corresp="p04050013"/><q><persName>Lisabetta</persName>, thou dost nought but call me, and vex thyself for my
  long tarrying, and bitterly upbraid me with thy tears; wherefore be
  <pb n="298"/>it known to thee that return to thee I may not, because the last day
  that thou didst see me thy brothers slew me.</q> After which, he
@@ -10533,7 +10533,7 @@ i.e.<!--(/i)--> Angel Gabriel.</note> before his resuscitation.</p><p><milestone
  the basil burgeoned out in exceeding great beauty and fragrance.
  And, the girl persevering ever in this way of life, the neighbours from
  <pb n="299"/>time to time took note of it, and when her brothers marvelled to see
- her beauty ruined, and her eyes as it were <persName>eva</persName>nished from her head,
+ her beauty ruined, and her eyes as it were evanished from her head,
  they told them of it, saying: <q>We have observed that such is her
  daily wont.</q> Whereupon the brothers, marking her behaviour, chid
  her therefore once or twice, and as she heeded them not, caused the
@@ -10641,7 +10641,7 @@ i.e.<!--(/i)--> Angel Gabriel.</note> before his resuscitation.</p><p><milestone
 	which it was made. When 'twas ended, Pamfilo received the
 	king's command to follow suit, and thus spoke:</p></body></floatingText><floatingText type="frame"><body><p><milestone unit="locus" corresp="p04060003"/>By the dream
 	told in the foregoing story I am prompted to relate one in which
-	two dreams are told, dreams of that which was to come, as L<persName>isabetta</persName>'s
+	two dreams are told, dreams of that which was to come, as <persName>Lisabetta</persName>'s
 	was of that which had been, and which were both fulfilled
 	almost as soon as they were told by those that had dreamed them.
 	<milestone unit="locus" corresp="p04060004"/>Wherefore, loving ladies, you must know that 'tis the common
@@ -11073,7 +11073,7 @@ i.e.<!--(/i)--> Angel Gabriel.</note> before his resuscitation.</p><p><milestone
  him a great scolding, not for his refusing to go to <placeName>Paris</placeName>, but for his
  love; which done, she plied him with soft, wheedling words, and
  <pb n="315"/>endearing expressions and gentle entreaties that he would be pleased
- to do as his guardians would have him; whereby at length she pr<persName>eva</persName>iled
+ to do as his guardians would have him; whereby at length she prevailed
  so far, that he consented to go to <placeName>Paris</placeName> for a year and no more;
  and so 'twas arranged. <milestone unit="locus" corresp="p04080014"/>To <placeName>Paris</placeName> accordingly our ardent lover went,
  and there under one pretext or another was kept for two years. He
@@ -11582,7 +11582,7 @@ i.e.<!--(/i)--> Angel Gabriel.</note> before his resuscitation.</p><p><milestone
  into the house; else I will pay thee for that turn and this to boot.</q>
  <milestone unit="locus" corresp="p04100047"/>The maid, deeming that she had come off well in the first brush,
  hied her with all speed to the prison where Ruggieri lay, and by her
- cajoleries pr<persName>eva</persName>iled upon the warders to let her speak with him; and
+ cajoleries prevailed upon the warders to let her speak with him; and
  having told him how he must answer the Stadic if he would get off,
  she succeeded in obtaining preaudience of the Stadic; 
 <milestone unit="locus" corresp="p04100048"/>who, seeing
@@ -12214,7 +12214,7 @@ i.e.<!--(/i)--> Angel Gabriel.</note> before his resuscitation.</p><p><milestone
  pity, and persuaded her to come with her into her hut, and there by
  coaxing drew from her how she was come thither; and knowing
  that she could not but be fasting, she set before her her own coarse
- bread and some fish and water, and pr<persName>eva</persName>iled upon her to eat a little.
+ bread and some fish and water, and prevailed upon her to eat a little.
  <milestone unit="locus" corresp="p05020021"/>Gostanza thereupon asked her, who she was that thus spoke Latin;
  whereto she answered that her name was <persName>Carapresa</persName>, and that she
  was from <placeName>Trapani</placeName>, where she had served some Christian fishermen.
@@ -13113,7 +13113,7 @@ i.e.<!--(/i)--> Angel Gabriel.</note> before his resuscitation.</p><p><milestone
  by name, who was well provided, as with other temporal goods, so
  also with children.  <milestone unit="locus" corresp="p05070004"/>For which cause being in need of servants, he
  took occasion of the appearance in <placeName>Trapani</placeName> waters of certain Genoese
- corsairs from the L<persName>eva</persName>nt, who, scouring the coast of <placeName>Armenia</placeName>,
+ corsairs from the Levant, who, scouring the coast of <placeName>Armenia</placeName>,
  had captured not a few boys, to purchase of them some of these
  youngsters, supposing them to be Turks; among whom, albeit most
  shewed as mere shepherd boys, there was one, Teodoro by name,
@@ -14459,7 +14459,7 @@ face,
 more to her that day.</p><p><milestone unit="locus" corresp="p06030012"/>In such a case, then, the lady having received
 a bite, 'twas allowable
  in her wittily to return it.</p></div><pb n="82"/><!--*********************************Novella 4***************************************--><div type="novella" corresp="nov0604"><head>Novel IV</head><argument><p><milestone unit="locus" corresp="p06040001"/><!--(i)--><persName>Chichibio</persName>, cook to <persName>Currado</persName> Gianfigliazzi, owes his
-	safety to a ready answer, whereby he converts <persName>Currado</persName>'s wrath into laughter, and <persName>eva</persName>des
+	safety to a ready answer, whereby he converts <persName>Currado</persName>'s wrath into laughter, and evades
 	the evil fate with which <persName>Currado</persName> had threatened him.<!--(/i)--></p></argument><floatingText type="frame"><body><p><milestone unit="locus" corresp="p06040002"/><!--(sc)--><persName>Lauretta</persName><!--(/sc)--> being now silent, all lauded Nonna to
 	the skies; after which <persName>Neifile</persName> received the queen's command to follow suit, and thus
 	began:</p></body></floatingText><floatingText type="frame"><body><p><milestone unit="locus" corresp="p06040003"/>Albeit, loving ladies, ready wit not seldom ministers words apt and
@@ -14599,9 +14599,9 @@ appearance.<!--(/i)--></p></argument><floatingText type="frame"><body><p><milest
 	ignoble of human forms.</p></body></floatingText><p><milestone unit="locus" corresp="p06050004"/>Whereof a notable example is afforded by two of our citizens,
  of whom I purpose for a brief while to discourse. The one, Messer Forese da Rabatta by
  name, was short and deformed of person and withal flat-cheeked and flat-nosed, insomuch
- that never a <persName>Baronci</persName>o<note>The name of a Florentine family famous for the extraordinary
+ that never a <persName>Baroncio</persName><note>The name of a Florentine family famous for the extraordinary
  ugliness of its men: whereby it came to pass that any grotesque or extremely ugly man was
- called a <persName>Baronci</persName>o. Fanfani, <!--(i)-->Vocab. della Lingua Italiana<!--(/i)-->,
+ called a <persName>Baroncio</persName>. Fanfani, <!--(i)-->Vocab. della Lingua Italiana<!--(/i)-->,
  1891.</note> had a visage so misshapen but his would have shewed as hideous beside it;
  yet so conversant was this man with the laws, that by not a few of those well able to
  form an opinion he was reputed a veritable storehouse of civil jurisprudence. 
@@ -14772,7 +14772,7 @@ to boot. <milestone unit="locus" corresp="p06060017"/>Wherefore 'twas not withou
  Pamfilo, being minded to
 declare Messer Forese's ill-favouredness,
  said that he would have been
-hideous beside a <persName>Baronci</persName>o.</p></div><pb n="90"/><!--*********************************Novella 7***************************************--><div type="novella" corresp="nov0607"><head>Novel VII</head><argument>      <p><milestone unit="locus" corresp="p06070001"/><!--(i)-->Madonna Filippa, being found by her husband with her
+hideous beside a <persName>Baroncio</persName>.</p></div><pb n="90"/><!--*********************************Novella 7***************************************--><div type="novella" corresp="nov0607"><head>Novel VII</head><argument>      <p><milestone unit="locus" corresp="p06070001"/><!--(i)-->Madonna Filippa, being found by her husband with her
 	lover, is cited before the court, and by a ready and
 	jocund answer acquits herself, and brings about an alteration of the
 	statute.<!--(/i)--></p>
@@ -15088,7 +15088,7 @@ achieved?</q> <milestone unit="locus" corresp="p06090012"/>Guido, seeing
 Thereupon he
  laid his hand on one of the great tombs, and being very
 nimble,
- vaulted over it, and so <persName>eva</persName>ded them, and went his way, <milestone unit="locus" corresp="p06090013"/>while they
+ vaulted over it, and so evaded them, and went his way, <milestone unit="locus" corresp="p06090013"/>while they
 remained gazing in one another's faces, and some said that he had
  taken
 leave of his wits, and that his answer was but nought, seeing
@@ -16190,7 +16190,7 @@ amorous maiden--Peronella was her name--who eked out by spinning what her husban
 his craft; and so the pair managed as best they might on very slender
 means. <milestone unit="locus" corresp="p07020008"/>And as chance would have it, one of the gallants of the city, taking
 note of this Peronella one day, and being mightily pleased with her, fell in love with
-her, and by this means and that so pr<persName>eva</persName>iled that he won her to accord him her
+her, and by this means and that so prevailed that he won her to accord him her
 intimacy. <milestone unit="locus" corresp="p07020009"/>Their times of forgathering they concerted as follows: to wit, that,
 her husband being wont to rise betimes of a morning to go to work or seek for work, the
 gallant was to be where he might see him go forth, and, the street where she dwelt, which
@@ -16427,7 +16427,7 @@ ushered them forth of the house, commending them to God; and without delay had t
 image made, and directed it to be set up with the others in front of the statue of St.
 Ambrose, not, be it understood, St. Ambrose of <placeName>Milan</placeName>.<note>The statue would doubtless be
 that of St.  Ambrose of <placeName>Siena</placeName>, of the Dominican Order.</note></p></div><pb n="129"/><!--***********************************Novella 4*********************************--><div type="novella" corresp="nov0704"><head>Novel IV</head><argument><p><milestone unit="locus" corresp="p07040001"/><!--(i)-->Tofano one night locks his
-wife out of the house: she, finding that by no entreaties may she pr<persName>eva</persName>il upon him to let
+wife out of the house: she, finding that by no entreaties may she prevail upon him to let
 her in, feigns to throw herself into a well, throwing therein a great stone. Tofano hies
 him forth of the house, and runs to the spot: she goes into the house, and locks him out,
 and hurls abuse at him from
@@ -18341,7 +18341,7 @@ and in leading a brawl or a breakdown, no
  had not suffered him to take, either because the luck was not to be
  his, or because he was minded to cheat his comrades, to whom he
  should have shewn the stone as soon as he found it. <milestone unit="locus" corresp="p08030065"/>And so, with
- many words they hardly pr<persName>eva</persName>iled upon him to forgive his injured
+ many words they hardly prevailed upon him to forgive his injured
  wife, and leaving him to rue the ill-luck that had filled his house
  with stones, went their way.</p></div><pb n="194"/><!--***********************************Novella 4*********************************--><div type="novella" corresp="nov0804"><head>Novel IV</head><argument><p><milestone unit="locus" corresp="p08040001"/><!--(i)-->The rector of <placeName>Fiesole</placeName> loves a widow lady, by whom he is
  not loved, and thinking to lie with her, lies with her
@@ -19837,7 +19837,7 @@ and in leading a brawl or a breakdown, no
  peace and accord they all four breakfasted together. And thenceforth
  each of the ladies had two husbands, and each of the husbands two
  wives; nor was there ever the least dispute or contention between
- them on that score.</p></div><pb n="235"/><!--******************************Novella 9********************************--><div type="novella" corresp="nov0809"><head>Novel IX</head><argument><p><milestone unit="locus" corresp="p08090001"/><!--(i)-->Bruno and Buffalmacco pr<persName>eva</persName>il upon Master Simone, a
+ them on that score.</p></div><pb n="235"/><!--******************************Novella 9********************************--><div type="novella" corresp="nov0809"><head>Novel IX</head><argument><p><milestone unit="locus" corresp="p08090001"/><!--(i)-->Bruno and Buffalmacco prevail upon Master Simone, a
  physician, to betake him by night to a certain place,
  there to be enrolled in a company that go the course.
  Buffalmacco throws him into a foul ditch, and there
@@ -20208,7 +20208,7 @@ studied there, 'tis my opinion that you there studied the art of
  wisdom, I give you disjointedly to understand that without fail I will
  procure your enrolment in our company.</q></p><p><milestone unit="locus" corresp="p08090073"/>After this promise the honours lavished by the doctor upon the
  two men grew and multiplied; in return for which they diverted
- themselves by setting him a prancing upon every wildest <persName>chimera</persName> in
+ themselves by setting him a prancing upon every wildest chimera in
  the world; and promised, among other matters, to give him by way
  of mistress, the Countess of <placeName>Civillari</placeName>,<note>A public sink at
  <placeName>Florence</placeName>.</note>
@@ -20700,7 +20700,7 @@ studied there, 'tis my opinion that you there studied the art of
  the quality of my displeasure. <milestone unit="locus" corresp="p08100048"/>Such and so great is the love I bear
  you, that I have sold the best part of all that I possess, whereby I
  have already in this port merchandise to the value of more than two
- thousand florins, and expect from the L<persName>eva</persName>nt other goods to the
+ thousand florins, and expect from the Levant other goods to the
  value of above three thousand florins, and mean to set up a warehouse
  in this city, and live here, to be ever near you, for that I deem myself
  more blessed in your love than any other lover that lives.</q> 
@@ -21242,7 +21242,7 @@ studied there, 'tis my opinion that you there studied the art of
  jolly time with them than go about buying earth as if he must needs
  make pellets;<note><!--(i)-->I.e.<!--(/i)--> bolts of clay for the cross-bow.</note> but
  so far were they from effecting their purpose,
- <pb n="275"/>that they could not even pr<persName>eva</persName>il upon him to give them a single
+ <pb n="275"/>that they could not even prevail upon him to give them a single
  meal.  <milestone unit="locus" corresp="p09030006"/>Whereat as one day they grumbled, being joined by a comrade
  of theirs, one Nello, also a painter, they all three took counsel how
  they might wet their whistle at <persName>Calandrino</persName>'s expense; and, their
@@ -21385,7 +21385,7 @@ studied there, 'tis my opinion that you there studied the art of
  into the March of <placeName>Ancona</placeName>, as legate of the Pope, a cardinal, to whom
  he was much bounden, resolved to resort to him there, thinking thereby
  to improve his circumstances. So, having acquainted his father with
- his purpose, he pr<persName>eva</persName>iled upon him to give him there and then all that
+ his purpose, he prevailed upon him to give him there and then all that
  he would have given him during the next six months, that he might
  have the wherewith to furnish himself with apparel and a good mount,
  so as to travel in a becoming manner.  <milestone unit="locus" corresp="p09040007"/>And as he was looking out for
@@ -22181,7 +22181,7 @@ studied there, 'tis my opinion that you there studied the art of
  ushered out of the King's presence, and finding <persName>Melisso</persName> awaiting
  him, told him what manner of answer he had gotten.  <milestone unit="locus" corresp="p09090016"/>Which
  utterances of the King the two men pondered, but finding therein
- nought that was helpful or rel<persName>eva</persName>nt to their need, they doubted
+ nought that was helpful or relevant to their need, they doubted
  the King had but mocked them, and set forth upon their homeward
  journey.</p><p>Now when they had been some days on the road, they came to
  a river, which was spanned by a fine bridge, and a great caravan of
@@ -22213,7 +22213,7 @@ studied there, 'tis my opinion that you there studied the art of
  yet find Solomon's counsel sound and good, for that I knew not how
  to beat my wife is abundantly clear to me; and this muleteer has
  shewn me what I have to do.</q></p><p><milestone unit="locus" corresp="p09090023"/>Now some days afterwards they arrived at Antioch, where
- <persName>Giosefo</persName> pr<persName>eva</persName>iled upon <persName>Melisso</persName> to tarry with him and rest a day or
+ <persName>Giosefo</persName> prevailed upon <persName>Melisso</persName> to tarry with him and rest a day or
  two; and meeting with but a sorry welcome on the part of his wife,
  he told her to take her orders as to supper from <persName>Melisso</persName>, who, seeing
  that such was <persName>Giosefo</persName>'s will, briefly gave her his instructions; which
@@ -23999,7 +23999,7 @@ studied there, 'tis my opinion that you there studied the art of
  Titus, and bade him go get him to bed with his lady.  <milestone unit="locus" corresp="p00080048"/>Whereat Titus
  gave way to shame, and would have changed his mind, and refused
  to go in; but Gisippus, no less zealous at heart than in words to
- serve his friend, after no small contention pr<persName>eva</persName>iled on him to go
+ serve his friend, after no small contention prevailed on him to go
  thither. Now no sooner was Titus abed with the lady, than, taking
  <pb n="360"/>her in his arms, he, as if jestingly, asked in a low tone whether she
  were minded to be his wife.  <milestone unit="locus" corresp="p00080049"/>She, taking him to be Gisippus,
@@ -24412,7 +24412,7 @@ studied there, 'tis my opinion that you there studied the art of
  and accordingly, that it might not be in their power to decline it, had
  brought them to his house by a ruse. And so, returning his greeting:
  <q>Sir,</q> quoth he, <q>were it meet to find fault with those that shew
- courtesy, we should have a gri<persName>eva</persName>nce against you, for that, to say
+ courtesy, we should have a grievance against you, for that, to say
  nought of somewhat delaying our journey, you have in guerdon of
  a single greeting constrained us to accept so noble a courtesy as
  yours.</q>  <milestone unit="locus" corresp="p00090014"/>Whereto the knight, who was of good understanding and


### PR DESCRIPTION
I noticed and fixed some errors like this: `to<persName>morrow</persName>` where the tag is holding the middle or end or beginning of a word. There might be other problems in the tagging like that to hunt for: It's easy to repair with regular expressions. 
